### PR TITLE
Add Parent() method to Collection and DataObject

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019. Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2019, 2020. Genome Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -136,6 +136,13 @@ func (coll *Collection) Ensure() error {
 	}
 
 	return nil
+}
+
+// Parent returns a new Collection that is the parent of this collection. If
+// the collection is the root level (i.e. the iRODS zone), the root level "/"
+// is returned.
+func (coll *Collection) Parent() *Collection {
+	return NewCollection(coll.client, filepath.Dir(coll.IPath))
 }
 
 func (coll *Collection) Remove() error {

--- a/collection_test.go
+++ b/collection_test.go
@@ -208,6 +208,38 @@ var _ = Describe("Put a Collection into iRODS", func() {
 	})
 })
 
+var _ = Describe("Get the parent of a collection", func() {
+	var (
+		client *ex.Client
+		err    error
+	)
+
+	BeforeEach(func() {
+		client, err = ex.FindAndStart(batonArgs...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		client.StopIgnoreError()
+	})
+
+	When("a collection is not the root", func() {
+		It("should have an appropriate parent", func() {
+			coll := ex.NewCollection(client, "/testZone/home/irods")
+			Expect(coll.Parent().RodsPath()).To(Equal("/testZone/home"))
+			Expect(coll.Parent().Parent().RodsPath()).To(Equal("/testZone"))
+			Expect(coll.Parent().Parent().Parent().RodsPath()).To(Equal("/"))
+		})
+	})
+
+	When("a collection is the root", func() {
+		It("should return itself as parent", func() {
+			coll := ex.NewCollection(client, "/")
+			Expect(coll.Parent().RodsPath()).To(Equal("/"))
+		})
+	})
+})
+
 var _ = Describe("Ensure that a Collection exists", func() {
 	var (
 		client *ex.Client

--- a/data_object.go
+++ b/data_object.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019. Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2019, 2020. Genome Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -132,6 +132,11 @@ func ArchiveDataObject(client *Client, localPath string, remotePath string,
 	err = obj.ReplaceMetadata(UniqAVUs(allAVUs))
 
 	return obj, err
+}
+
+// Parent returns a new Collection that is containing this data object.
+func (obj *DataObject) Parent() *Collection {
+	return NewCollection(obj.client, obj.IPath)
 }
 
 // Remove removes (deletes) the data object.

--- a/data_object_test.go
+++ b/data_object_test.go
@@ -292,6 +292,29 @@ var _ = Describe("Archive a DataObject into iRODS", func() {
 	})
 })
 
+var _ = Describe("Get the parent of a data object", func() {
+	var (
+		client *ex.Client
+		err    error
+	)
+
+	BeforeEach(func() {
+		client, err = ex.FindAndStart(batonArgs...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		client.StopIgnoreError()
+	})
+
+	When("a data object is present", func() {
+		It("should have its collection as its parent", func() {
+			obj := ex.NewDataObject(client, "/testZone/home/irods/dummy.txt")
+			Expect(obj.Parent().RodsPath()).To(Equal("/testZone/home/irods"))
+		})
+	})
+})
+
 var _ = Describe("Replace metadata on a DataObject", func() {
 	var (
 		client *ex.Client


### PR DESCRIPTION
The Parent() method returns the Collection containing the
instance, with special rules for the root/zone level.