### PR TITLE
Add metadata methods to RodsItem and make operations idempotent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ services:
 language: go
 
 go:
-  - "1.12.5"
+  - "1.13"
+  - "1.14"
 
 env:
   global:

--- a/metadata.go
+++ b/metadata.go
@@ -32,6 +32,7 @@ const ChecksumAttr string = "md5"
 
 type AVUFilter func(avu AVU) bool
 
+// MakeAVU returns a new AVU instance.
 func MakeAVU(attr string, value string, units ...string) AVU {
 	var unit string
 	if len(units) > 0 {
@@ -41,6 +42,16 @@ func MakeAVU(attr string, value string, units ...string) AVU {
 	return AVU{Attr: attr, Value: value, Units: unit}
 }
 
+// MakeCreationMetadata returns the standard metadata to be added to a newly
+// created data object. The AVUs describe:
+//
+// - Who (which organisation) was responsible for creation of the data object
+// - Who (which user) published (wrote) the data object.
+// - What the checksum of the new data object was at the time of creation.
+// - When the data object was created.
+//
+// These are expressed (with the exception of the checksum) as Dublin Core
+// metadata https://www.dublincore.org/specifications/dublin-core/dcmi-terms/
 func MakeCreationMetadata(checksum string) []AVU {
 	when := time.Now().Format(time.RFC3339)
 	who, err := user.Current()


### PR DESCRIPTION
- Add some commonly-used metadata operations to the API.

  HasMetadatum() checks for the presence of a single AVU.

  HasSomeMetadata() checks for the presence of a some of a set of AVUs.

  HasAllMetadata() checks for the presence of all members of a set of
  AVUs.

- Change AddMetadata() and RemoveMetadata() to be idempotent.

  The errors they would raise (e.g. when adding an AVU that is already
  present) are not helpful, so this could be considered a bug fix,
  rather than an enhancement.

- Add some documentation.

- Test housekeeping

  Avoid using ex.MakeAVU. This function serves little use and harms
  readability, I plan to deprecate it.

  Run Travis tests on Go 1.13 and 1.14

  Tidying