### PR TITLE
Add iRODS 4.2.10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,16 +17,19 @@ jobs:
 
     strategy:
       matrix:
-        go: [ "1.16" ]
-        baton: [ "2.1.0" ]
-        experimental: [false]
         include:
-          - irods: "4.2.7"
+          # iRODS 4.2.10 clients vs 4.2.7 server
+          - go: "1.16"
+            irods: "4.2.10"
             server_image: "wsinpg/ub-16.04-irods-4.2.7:latest"
+            baton: "3.1.0"
             experimental: false
-          - irods: "4.2.8"
-            server_image: "wsinpg/ub-18.04-irods-4.2.8:latest"
-            experimental: true
+          # iRODS 4.2.10 clients vs 4.2.10 server
+          - go: "1.16"
+            irods: "4.2.10"
+            server_image: "wsinpg/ub-18.04-irods-4.2.10:latest"
+            baton: "3.1.0"
+            experimental: false
 
     services:
       irods:
@@ -53,14 +56,13 @@ jobs:
 
         conda config --set auto_update_conda False
         conda config --prepend channels "$WSI_CONDA_CHANNEL"
-        conda config --append channels conda-forge
         conda info
 
     - name: "Install iRODS clients"
       run: |
         conda create -y -n "$CONDA_TEST_ENVIRONMENT"
-        conda install -y -n "$CONDA_TEST_ENVIRONMENT" "irods-icommands ==${{ matrix.irods }}"
-        conda install -y -n "$CONDA_TEST_ENVIRONMENT" "baton ==${{ matrix.baton }}"
+        conda install -y -n "$CONDA_TEST_ENVIRONMENT" "irods-icommands=${{ matrix.irods }}"
+        conda install -y -n "$CONDA_TEST_ENVIRONMENT" "baton=${{ matrix.baton }}"
 
     - name: "Configure iRODS clients"
       run: |
@@ -74,7 +76,7 @@ jobs:
             "irods_user_name": "irods",
             "irods_zone_name": "testZone",
             "irods_home": "/testZone/home/irods",
-            "irods_default_resource": "testResc"
+            "irods_default_resource": "replResc"
         }
         EOF
 

--- a/client.go
+++ b/client.go
@@ -59,9 +59,9 @@ const (
 	RodsCatCollectionNotEmpty = int32(-821000) // iRODS: collection not empty
 )
 
-// Timeout for the baton-do sub-process to respond or confirm that it is still
-// running. Significant response times can be real, for example responding
-// after a put operation on 1 TiB of data.
+// DefaultResponseTimeout is a timeout for the baton-do sub-process to respond
+// or confirm that it is still  running. Significant response times can be real,
+// for example responding after a put operation on 1 TiB of data.
 var DefaultResponseTimeout = 5 * time.Second
 
 // Client is a launcher for a baton sub-process which holds its system I/O
@@ -140,7 +140,7 @@ type ResultWrapper struct {
 	List *[]RodsItem `json:"multiple,omitempty"`
 }
 
-// ErrMsg allows handling of an iRODS error message in JSON.
+// ErrorMsg allows handling of an iRODS error message in JSON.
 type ErrorMsg struct {
 	Message string `json:"message"`
 	Code    int32  `json:"code"`
@@ -213,6 +213,25 @@ func FindBaton() (string, error) {
 	}
 
 	return filepath.Clean(baton), err
+}
+
+// BatonVersion reports the version string printed by baton-do --version
+func BatonVersion() (string, error) {
+	baton, err := FindBaton()
+	if err != nil {
+		return baton, err
+	}
+
+	cmd := exec.Command(baton, "--version")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	err = cmd.Run()
+	if err != nil {
+		return baton, err
+	}
+
+	return strings.TrimSpace(out.String()), err
 }
 
 // FindAndStart locates the baton-do executable using FindBaton, creates a
@@ -330,8 +349,8 @@ func (client *Client) Start(arg ...string) (*Client, error) {
 			case <-ctx.Done():
 				return
 			default:
-				// On cancelling, this is unblocked by the send goroutine
-				// closing stdin and we should reach EOF
+				// On cancelling, this is unblocked by the "send" goroutine
+				// closing stdin, and we should reach EOF
 				bout, re := rd.ReadBytes('\n')
 				if re == nil {
 					pout <- bytes.TrimRight(bout, "\r\n")
@@ -359,8 +378,8 @@ func (client *Client) Start(arg ...string) (*Client, error) {
 			case <-ctx.Done():
 				return
 			default:
-				// On cancelling, this is unblocked by the send goroutine
-				// closing stdin and we should reach EOF
+				// On cancelling, this is unblocked by the "send" goroutine
+				// closing stdin, and we should reach EOF
 				bout, re := rd.ReadBytes('\n')
 				if re == nil {
 					out := bytes.TrimRight(bout, "\r\n")
@@ -446,8 +465,8 @@ func (client *Client) Runtime() time.Duration {
 	return client.stopTime.Sub(client.startTime)
 }
 
-// Stop stops the baton sub-process, if it is running. Ignores any error
-// from the sub-process.
+// StopIgnoreError stops the baton sub-process, if it is running. Ignores any
+// error from the sub-process.
 func (client *Client) StopIgnoreError() {
 	if err := client.Stop(); err != nil {
 		logs.GetLogger().Error().Err(err).Int("pid", client.pid).
@@ -620,7 +639,7 @@ func (client *Client) MkDir(args Args, item RodsItem) (RodsItem, error) {
 	return items[0], err
 }
 
-// Puts a collection or data object into iRODS and returns the item. By
+// Put a collection or data object into iRODS and returns the item. By
 // setting Args.Recurse=true, the operation may be made recursive on a
 // collection.
 func (client *Client) Put(args Args, item RodsItem) ([]RodsItem, error) {
@@ -749,8 +768,8 @@ func (client *Client) putRecurse(args Args, item RodsItem) ([]RodsItem, error) {
 	return newItems, nil
 }
 
-// execute sends JSON to a baton-do proecess, which in turn passes a request to
-// the iRODS server. This methdd handles the write locking while a call to the
+// execute sends JSON to a baton-do process, which in turn passes a request to
+// the iRODS server. This method handles write locking while a call to the
 // iRODS server is being run.
 func (client *Client) execute(op string, args Args, item RodsItem) ([]RodsItem,
 	error) {
@@ -854,6 +873,10 @@ func unwrap(client *Client, envelope *Envelope) ([]RodsItem, error) {
 		}
 		SortRodsItems(contents)
 		items[i].IContents = contents
+
+		var reps = items[i].IReplicates
+		SortReplicates(reps)
+		items[i].IReplicates = reps
 
 		var avus = items[i].IAVUs
 		SortAVUs(avus)

--- a/client_pool.go
+++ b/client_pool.go
@@ -73,7 +73,7 @@ type ClientPoolParams struct {
 	MaxClientIdleTime time.Duration // Inactivity time after which clients are considered idle.
 }
 
-// The default argument values for client pool creation.
+// DefaultClientPoolParams is default argument values for client pool creation.
 var DefaultClientPoolParams = ClientPoolParams{
 	MaxSize:           10,
 	GetTimeout:        time.Millisecond * 250,

--- a/client_test.go
+++ b/client_test.go
@@ -27,7 +27,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	ex "github.com/wtsi-npg/extendo/v2"
 )
 
@@ -40,6 +39,12 @@ var _ = Describe("Find the baton-do executable", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(path).ToNot(BeEmpty())
 			Expect(filepath.Base(path)).To(Equal("baton-do"))
+		})
+
+		It("should report a version", func() {
+			version, err := ex.BatonVersion()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(MatchRegexp(`^\d+.\d+.\d+$`))
 		})
 	})
 
@@ -297,13 +302,53 @@ var _ = Describe("List an iRODS path", func() {
 
 				Expect(items).To(HaveLen(1))
 				reps := items[0].IReplicates
-				Expect(reps).To(HaveLen(1))
 
-				Expect(reps[0]).To(Equal(ex.Replicate{
-					Resource: "demoResc",
-					Location: "localhost",
-					Checksum: testChecksum,
-					Valid:    true}))
+				// NB: When baton is built against the iRODS 4.2.7 client
+				// libraries, it ignores the irods_default_resource in
+				// irods_environment.json. This causes files to hit a
+				// non-replication resource, even when one is requested,
+				// leading to a single replicates.
+				//
+				// When baton is built against the iRODS 4.2.10 client
+				// libraries, it respects the irods_default_resource in
+				// irods_environment.json.
+
+				// The replication resource assigns replicate number randomly.
+				expectedRepsX := []ex.Replicate{
+					{
+						Resource: "unixfs1",
+						Location: "localhost",
+						Checksum: testChecksum,
+						Number:   0,
+						Valid:    true,
+					},
+					{
+						Resource: "unixfs2",
+						Location: "localhost",
+						Checksum: testChecksum,
+						Number:   1,
+						Valid:    true},
+				}
+				expectedRepsY := []ex.Replicate{
+					{
+						Resource: "unixfs1",
+						Location: "localhost",
+						Checksum: testChecksum,
+						Number:   1,
+						Valid:    true,
+					},
+					{
+						Resource: "unixfs2",
+						Location: "localhost",
+						Checksum: testChecksum,
+						Number:   0,
+						Valid:    true,
+					},
+				}
+
+				Expect(reps).To(Or(
+					ConsistOf(expectedRepsX),
+					ConsistOf(expectedRepsY)))
 			})
 
 			It("should have timestamp information if requested", func() {
@@ -312,12 +357,30 @@ var _ = Describe("List an iRODS path", func() {
 
 				Expect(items).To(HaveLen(1))
 				stamps := items[0].ITimestamps
-				Expect(stamps).To(HaveLen(2))
+				Expect(stamps).To(Or(HaveLen(4)))
 
+				// TODO: We could write a custom matcher to allow us to use
+				// ConsistsOf. However, that needs a lot more code than the
+				// simple repetition below.
 				Expect(stamps[0].Created).
 					To(BeTemporally("~", time.Now(), time.Minute))
+				Expect(stamps[0].Modified).To(BeZero())
+				Expect(stamps[0].Replicates).To(Equal(0))
+
+				Expect(stamps[1].Created).To(BeZero())
 				Expect(stamps[1].Modified).
 					To(BeTemporally("~", time.Now(), time.Minute))
+				Expect(stamps[1].Replicates).To(Equal(0))
+
+				Expect(stamps[2].Created).
+					To(BeTemporally("~", time.Now(), time.Minute))
+				Expect(stamps[2].Modified).To(BeZero())
+				Expect(stamps[2].Replicates).To(Equal(1))
+
+				Expect(stamps[3].Created).To(BeZero())
+				Expect(stamps[3].Modified).
+					To(BeTemporally("~", time.Now(), time.Minute))
+				Expect(stamps[3].Replicates).To(Equal(1))
 			})
 
 			When("metadata are requested", func() {
@@ -365,6 +428,7 @@ var _ = Describe("List an iRODS path", func() {
 		})
 	})
 })
+
 
 var _ = Describe("Put a file into iRODS", func() {
 	var (

--- a/collection.go
+++ b/collection.go
@@ -155,7 +155,7 @@ func (coll *Collection) RemoveRecurse() error {
 	return err
 }
 
-// Contents returns the Collections from the collection contents. If the
+// Collections returns the Collections from the collection contents. If the
 // contents have not been Fetched, the slice will be empty.
 func (coll *Collection) Collections() []Collection {
 	var colls []Collection
@@ -169,7 +169,7 @@ func (coll *Collection) Collections() []Collection {
 	return colls
 }
 
-// Contents returns the DataObjects from the collection contents. If the
+// DataObjects returns the DataObjects from the collection contents. If the
 // contents have not been Fetched, the slice will be empty.
 func (coll *Collection) DataObjects() []DataObject {
 	var objs []DataObject


### PR DESCRIPTION
Tests to pass on iRODS 4.2.7 and 4.2.10.

Remove the conda-forge channel.

Use the convention of replResc as an iRODS test resource.

Add a BatonVersion function.

Add the JSON serialisation of Replicates in the Timestamp struct.

Add sorting of replicates in server responses.

Fix the JSON serialisation of Number in the Replicate struct.

Fix incorrect comparison of modified with created times in
SortTimestamps.

Fix some documentation strings.