### PR TITLE
Remove iRODS 4.1.* PutDataObject workaround and enable checksum verification

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }} # Experimental builds may fail
 
     defaults:
@@ -76,7 +76,8 @@ jobs:
             "irods_user_name": "irods",
             "irods_zone_name": "testZone",
             "irods_home": "/testZone/home/irods",
-            "irods_default_resource": "replResc"
+            "irods_default_resource": "replResc",
+            "irods_default_hash_scheme": "MD5"
         }
         EOF
 
@@ -98,7 +99,7 @@ jobs:
 
     - name: "Install test runner"
       run: |
-        go get github.com/onsi/ginkgo/ginkgo
+        go get github.com/onsi/ginkgo/v2/ginkgo
         go get github.com/onsi/gomega/...
 
     - name: "Run tests"

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ lint:
 check: test
 
 test:
-	ginkgo -r -slowSpecThreshold=30 -race
+	ginkgo -r -slow-spec-threshold=30s -race
 
 coverage:
-	ginkgo -r -slowSpecThreshold=30 -cover -coverprofile=coverage.out
+	ginkgo -r -slow-spec-threshold=30s -cover -coverprofile=coverage.out
 
 clean:
 	go clean

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ therefore baton is required for its operation.
 
 #### Dependencies:
 
+https://www.irods.org
+
+  Versions >= 4.2.7
+
 https://github.com/wtsi-npg/baton
 
   Versions >= 2.0.0

--- a/client.go
+++ b/client.go
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2019, 2020, 2021. Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2019, 2020, 2021, 2022. Genome Research Ltd. All rights
+ * reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,6 +58,7 @@ const (
 const (
 	RodsUserFileDoesNotExist  = int32(-310000) // iRODS: user file does not exist
 	RodsCatCollectionNotEmpty = int32(-821000) // iRODS: collection not empty
+	RodsUnixFileReadError     = int32(-512021) // iRODS: failed to read a file
 )
 
 // DefaultResponseTimeout is a timeout for the baton-do sub-process to respond
@@ -115,6 +117,8 @@ type Args struct {
 	AVU bool `json:"avu,omitempty"`
 	// Request checksums.
 	Checksum bool `json:"checksum,omitempty"`
+	// Request checksums are verified on put.
+	Verify bool `json:"verify,omitempty"`
 	// Restrict to collections.
 	Collection bool `json:"collection,omitempty"`
 	// Request collection contents.

--- a/client_pool_test.go
+++ b/client_pool_test.go
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2019, 2020, 2021. Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2019, 2020, 2021, 2022. Genome Research Ltd. All rights
+ * reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,7 +24,7 @@ package extendo_test
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	ex "github.com/wtsi-npg/extendo/v2"
@@ -211,11 +212,21 @@ var _ = Describe("Pool client runtime timeout", func() {
 			})
 
 			It("should stop those clients returned to it", func() {
-				time.Sleep(time.Second * 2)
+				allStopped := false
+				tries := 10
 
-				for _, c := range clients {
-					Expect(c.IsRunning()).To(BeFalse())
+				for i := 0; i < tries; i++ {
+					time.Sleep(time.Second * 1)
+					for _, c := range clients {
+						if c.IsRunning() {
+							continue
+						}
+						allStopped = true
+						break
+					}
 				}
+
+				Expect(allStopped).To(BeTrue())
 			})
 		})
 
@@ -244,11 +255,21 @@ var _ = Describe("Pool client runtime timeout", func() {
 			})
 
 			It("should stop those clients returned to it", func() {
-				time.Sleep(time.Second * 2)
+				allStopped := false
+				tries := 10
 
-				for _, c := range clients {
-					Expect(c.IsRunning()).To(BeFalse())
+				for i := 0; i < tries; i++ {
+					time.Sleep(time.Second * 1)
+					for _, c := range clients {
+						if c.IsRunning() {
+							continue
+						}
+						allStopped = true
+						break
+					}
 				}
+
+				Expect(allStopped).To(BeTrue())
 			})
 		})
 	})

--- a/client_test.go
+++ b/client_test.go
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2019, 2020, 2021. Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2019, 2020, 2021, 2022. Genome Research Ltd. All rights
+ * reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,7 +26,7 @@ import (
 	"path/filepath"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	ex "github.com/wtsi-npg/extendo/v2"
 )

--- a/collection_test.go
+++ b/collection_test.go
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2019, 2020, 2021. Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2019, 2020, 2021, 2022. Genome Research Ltd. All rights
+ * reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,7 +24,7 @@ package extendo_test
 import (
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	ex "github.com/wtsi-npg/extendo/v2"

--- a/data_object_test.go
+++ b/data_object_test.go
@@ -219,8 +219,8 @@ var _ = Describe("Archive a DataObject into iRODS", func() {
 	})
 
 	AfterEach(func() {
-		//err = removeTmpCollection(workColl)
-		//Expect(err).NotTo(HaveOccurred())
+		err = removeTmpCollection(workColl)
+		Expect(err).NotTo(HaveOccurred())
 
 		client.StopIgnoreError()
 	})

--- a/data_object_test.go
+++ b/data_object_test.go
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2019, 2020, 2021. Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2019, 2020, 2021, 2022. Genome Research Ltd. All rights
+ * reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,7 +24,7 @@ package extendo_test
 import (
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	ex "github.com/wtsi-npg/extendo/v2"
@@ -218,8 +219,8 @@ var _ = Describe("Archive a DataObject into iRODS", func() {
 	})
 
 	AfterEach(func() {
-		err = removeTmpCollection(workColl)
-		Expect(err).NotTo(HaveOccurred())
+		//err = removeTmpCollection(workColl)
+		//Expect(err).NotTo(HaveOccurred())
 
 		client.StopIgnoreError()
 	})
@@ -311,7 +312,9 @@ var _ = Describe("Archive a DataObject into iRODS", func() {
 			code, e := ex.RodsErrorCode(err)
 			Expect(e).NotTo(HaveOccurred())
 
-			Expect(code).To(Equal(ex.RodsUserFileDoesNotExist))
+			// With checksum verification enabled, iRODS tries to read the local file
+			// first, which in this test is intentionally a directory.
+			Expect(code).To(Equal(ex.RodsUnixFileReadError))
 		})
 	})
 })

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wtsi-npg/extendo/v2
 go 1.17
 
 require (
-	github.com/onsi/ginkgo v1.16.5
+	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.2
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.28.0
@@ -14,15 +14,12 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.3.7 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -35,13 +34,11 @@ github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
-github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/ginkgo/v2 v2.1.6 h1:Fx2POJZfKRQcM1pH49qSZiYeu319wji004qX+GDovrU=
@@ -155,7 +152,6 @@ google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2019, 2020, 2021. Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2019, 2020, 2021, 2022. Genome Research Ltd. All rights
+ * reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +27,7 @@ import (
 	"os"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 
 	ex "github.com/wtsi-npg/extendo/v2"
 )

--- a/suite_test.go
+++ b/suite_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019, 2021. Genome Research Ltd. All rights reserved.
+ * Copyright (C) 2019, 2021, 2022. Genome Research Ltd. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rs/zerolog"
 	logs "github.com/wtsi-npg/logshim"


### PR DESCRIPTION
Remove the 2-stage put implementation for iRODS 4.1.* Enable iRODS' own local vs. remote checksum verification Make some tests less fragile
Update Ginkgo from v1 to v2