### PR TITLE
Do not hang if baton client crashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ lint:
 check: test
 
 test:
-	ginkgo -r -slow-spec-threshold=30s -race
+	ginkgo -r -race
 
 coverage:
-	ginkgo -r -slow-spec-threshold=30s -cover -coverprofile=coverage.out
+	ginkgo -r -cover -coverprofile=coverage.out
 
 clean:
 	go clean

--- a/client_test.go
+++ b/client_test.go
@@ -163,6 +163,21 @@ var _ = Describe("List an iRODS path", func() {
 		})
 	})
 
+	When("the path does not exist and contains printf placeholders", func() {
+		It("should return an iRODS -310000 error", func() {
+			path := filepath.Join(rootColl, "%s")
+			item := ex.RodsItem{IPath: path}
+
+			_, err := client.ListItem(ex.Args{}, item)
+			Expect(err).To(HaveOccurred())
+
+			code, e := ex.RodsErrorCode(err)
+			Expect(e).NotTo(HaveOccurred())
+
+			Expect(code).To(Equal(ex.RodsUserFileDoesNotExist))
+		})
+	})
+
 	When("the item is a collection", func() {
 		BeforeEach(func() {
 			testColl = ex.RodsItem{IPath: filepath.Join(workColl, "testdata")}
@@ -429,7 +444,6 @@ var _ = Describe("List an iRODS path", func() {
 		})
 	})
 })
-
 
 var _ = Describe("Put a file into iRODS", func() {
 	var (


### PR DESCRIPTION
Reorder the completion goroutine so that cmd.Wait() is called before waiting
for the IO goroutines.

Use client.IsRunning() to avoid data races checking for client state.

Add a regression test specifically for the cause of the original crash. This
will fail (now that we don't hang) and will pass once the baton client itself
if fixed.