### PR TITLE
Fix baton STDOUT/STDERR goroutines raising os.ErrClosed before EOF

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,6 +18,12 @@ jobs:
     strategy:
       matrix:
         include:
+          # iRODS 4.2.11 clients vs 4.2.7 server - regression test for https://github.com/wtsi-npg/extendo/issues/132
+          - go: "1.18"
+            irods: "4.2.11"
+            server_image: "ghcr.io/wtsi-npg/ub-16.04-irods-4.2.7:latest"
+            baton: "4.0.0"
+            experimental: false
           # iRODS 4.2.11 clients vs 4.2.7 server
           - go: "1.18"
             irods: "4.2.11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - [![Unit tests](https://github.com/wtsi-npg/extendo/actions/workflows/run-tests.yml/badge.svg)](https://github.com/wtsi-npg/extendo/actions/workflows/run-tests.yml)
 
+### Fixed
+
+- Noisy error log due to logging os.ErrClosed in the client goroutines reading
+  from baton STDOUT/STDERR. This error was raised because the subprocess could
+  close the reader before EOF was reached. The fix is to first wait for EOF once
+  the client has been cancelled.
+
 ## [2.6.0] - 2023-04-17
 
 ### Fixed


### PR DESCRIPTION
Noisy error log due to logging os.ErrClosed in the client goroutines reading from baton STDOUT/STDERR. This error was raised because the subprocess could close the reader before EOF was reached. The fix is to first wait for EOF once the client has been cancelled.