### PR TITLE
Update test matrix iRODS versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,20 +17,21 @@ jobs:
     strategy:
       matrix:
         include:
-          # iRODS 4.2.11 clients vs 4.2.7 server
-          - irods: "4.2.11"
-            client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.11:latest"
+          - irods: "4.2.7"
+            client_image: "ghcr.io/wtsi-npg/ub-16.04-irods-clients-4.2.7:latest"
             server_image: "ghcr.io/wtsi-npg/ub-16.04-irods-4.2.7:latest"
             experimental: false
-          # iRODS 4.2.11 clients vs 4.2.11 server
           - irods: "4.2.11"
             client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.11:latest"
             server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.11:latest"
             experimental: false
-          # iRODS 4.2.12 clients vs 4.2.12 server
           - irods: "4.2.12"
             client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.12:latest"
             server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.12:latest"
+            experimental: false
+          - irods: "4.3.0"
+            client_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-4.3-nightly:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3-nightly:latest"
             experimental: true
 
     services:


### PR DESCRIPTION
Remove the combination of 4.2.11 clients with a 4.2.7 server

Add the combination of 4.2.7 clients with a 4.2.7 server Add the combination of 4.3-nightly clients with a 4.3-nightly server