### PR TITLE
Add basic support for physical_path (baton 6.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - [![Unit tests](https://github.com/wtsi-npg/extendo/actions/workflows/run-tests.yml/badge.svg)](https://github.com/wtsi-npg/extendo/actions/workflows/run-tests.yml)
 
+### Added
+
+- Capture the replicate `physical_path` field reported by baton >= 6.1.0.
+
 ## [2.6.1] - 2023-04-25
 
 ### Fixed

--- a/client_test.go
+++ b/client_test.go
@@ -421,9 +421,36 @@ var _ = Describe("List an iRODS path", func() {
 					},
 				}
 
+				// physical_path is only reported by baton >= 6.1.0 and is
+				// deployment-specific; blank it for this structural comparison.
+				for i := range reps {
+					reps[i].PhysicalPath = ""
+				}
+
 				Expect(reps).To(Or(
 					ConsistOf(expectedRepsX),
 					ConsistOf(expectedRepsY)))
+			})
+
+			It("should have replicate physical paths if requested", func() {
+				// Older baton does not report physical_path; skip there.
+				version, err := ex.BatonVersion()
+				Expect(err).NotTo(HaveOccurred())
+
+				if !batonReportsPhysicalPath(version) {
+					Skip("baton " + version + " does not report physical_path")
+				}
+
+				items, err := client.List(ex.Args{Replicate: true}, testObj)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(items).To(HaveLen(1))
+				reps := items[0].IReplicates
+				Expect(reps).ToNot(BeEmpty())
+
+				for _, rep := range reps {
+					Expect(rep.PhysicalPath).ToNot(BeEmpty())
+				}
 			})
 
 			It("should have timestamp information if requested", func() {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -26,11 +26,31 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 
 	ex "github.com/wtsi-npg/extendo/v3"
 )
+
+// batonReportsPhysicalPath reports whether the given baton version (from
+// baton-do --version) supports the replicate physical_path field, added in
+// baton 6.1.0. Unparseable versions are treated as unsupported.
+func batonReportsPhysicalPath(version string) bool {
+	parts := strings.Split(strings.TrimSpace(version), ".")
+	if len(parts) < 2 {
+		return false
+	}
+
+	major, errMajor := strconv.Atoi(parts[0])
+	minor, errMinor := strconv.Atoi(parts[1])
+	if errMajor != nil || errMinor != nil {
+		return false
+	}
+
+	return major > 6 || (major == 6 && minor >= 1)
+}
 
 type itemPathTransform func(i []ex.RodsItem) []string
 type collPathTransform func(i []ex.Collection) []string

--- a/rodsitem.go
+++ b/rodsitem.go
@@ -472,6 +472,9 @@ type Replicate struct {
 	Number uint16 `json:"number"`
 	// Valid is iRODS' flag describing whether the replicate is up-to-date
 	Valid bool `json:"valid"`
+	// PhysicalPath is the replicate's file path on the resource server
+	// (reported by baton >= 6.1.0; missing for older baton)
+	PhysicalPath string `json:"physical_path,omitempty"`
 }
 
 // SortReplicates sorts reps by Resource, then Location, then Number, then


### PR DESCRIPTION
This should make extendo aware of the extra field returned by baton 6.1.0. The biggest change was in tests to be able to change behaviour depending of the baton version being used for testing. This should work for both cases. But add complexity in tests. Matrix always tests against latest release of `contianers` so this could be simplified if we are happy to break tests for older versions.

No addressing other functionality, was wondering if there is value to add the field to for example `SortReplicates` but that may not be wanted/necessary so I stopped here.